### PR TITLE
README: Fix typo in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ compiler and make.
 $ git clone https://github.com/shenki/libscrewmysecurity
 $ cd libscrewmysecurity
 $ make
-$ LD_PRELOAD./libscrewmysecurity.so wget https://internaldomain/important-file.txt
+$ LD_PRELOAD=./libscrewmysecurity.so wget https://internaldomain/important-file.txt
 ```
 
 ## How it works


### PR DESCRIPTION
Add missing = sign in example usage.

Signed-off-by: Andrew Donnellan <andrew@donnellan.id.au>